### PR TITLE
Add EMMAA importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,22 @@ Biological applications for [y0](https://github.com/y0-causal-inference/y0).
 
 ## 💪 Getting Started
 
-> TODO show in a very small amount of space the **MOST** useful thing your package can do.
-Make it as short as possible! You have an entire set of docs for later.
+
+Check that your BEL graph is identifiable under a causal query:
+
+```python
+import pybel
+from y0.dsl import P, Variable
+from y0.identify import is_identifiable
+from y0_bio.resources import BEL_EXAMPLE
+from y0_bio.io.bel import bel_to_nxmg
+bel_graph = pybel.load(BEL_EXAMPLE)
+nxmg = bel_to_nxmg(bel_graph)
+assert is_identifiable(
+    nxmg,
+    P(Variable('Severe Acute Respiratory Syndrome') @ Variable('angiotensin II')),
+)
+```
 
 ## ⬇️ Installation
 

--- a/docs/source/bel.rst
+++ b/docs/source/bel.rst
@@ -1,0 +1,4 @@
+BEL Tools
+=========
+.. automodule:: y0_bio.io.bel
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@ y0-bio |release| Documentation
    :name: start
 
    installation
+   bel
    cli
 
 Indices and Tables

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ install_requires =
     y0>=0.0.3
     # Biopragmatics Stack
     pybel
+    indra
 
 
 # Random options

--- a/src/y0_bio/io/bel.py
+++ b/src/y0_bio/io/bel.py
@@ -8,7 +8,6 @@ import pybel
 import pybel.constants as pc
 from ananke.graphs import ADMG
 from pybel import BELGraph
-from pybel.dsl import Protein
 
 from y0.graph import NxMixedGraph
 
@@ -55,21 +54,27 @@ def bel_to_nxmg(
     if indirect_handler not in VALID:
         raise ValueError(f'invalid indirect edge handler: {indirect_handler}. Should be in {VALID}')
     for u, v, d in bel_graph.edges(data=True):
-        if not isinstance(u, Protein) or not isinstance(v, Protein):
-            continue
-        if u.namespace.lower() != 'hgnc' or v.namespace.lower() != 'hgnc':
+        try:
+            u_name = u.name
+        except AttributeError:
+            u_name = str(u)
+        try:
+            v_name = v.name
+        except AttributeError:
+            v_name = str(v)
+        if u_name == v_name:
             continue
         if d[pc.RELATION] in CORRELATIVE_RELATIONS:
-            rv.add_undirected_edge(u.name, v.name)
+            rv.add_undirected_edge(u_name, v_name)
         elif include_associations and d[pc.RELATION] == pc.ASSOCIATION:
-            rv.add_undirected_edge(u.name, v.name)
+            rv.add_undirected_edge(u_name, v_name)
         elif d[pc.RELATION] in pc.DIRECT_CAUSAL_RELATIONS:
-            rv.add_directed_edge(u.name, v.name)
+            rv.add_directed_edge(u_name, v_name)
         elif d[pc.RELATION] in pc.INDIRECT_CAUSAL_RELATIONS:
             if indirect_handler == 'bi':
-                rv.add_undirected_edge(u.name, v.name)
+                rv.add_undirected_edge(u_name, v_name)
             elif indirect_handler == 'di':
-                rv.add_directed_edge(u.name, v.name)
+                rv.add_directed_edge(u_name, v_name)
     return rv
 
 
@@ -87,6 +92,15 @@ def bel_to_admg(
     :param indirect_handler: How should indirected edges be handled? If 'bi', adds as bidirected edges. Elif 'di',
         adds as bidirected edges. If 'skip', do not include. If None, defaults to 'bi'.
     :return: An Ananke ADMG
+
+    >>> import pybel
+    >>> from y0.dsl import P, Variable
+    >>> from y0.identify import is_identifiable
+    >>> from y0_bio.resources import BEL_EXAMPLE
+    >>> from y0_bio.io.bel import bel_to_nxmg
+    >>> bel_graph = pybel.load(BEL_EXAMPLE)
+    >>> nxmg = bel_to_nxmg(bel_graph)
+    >>> is_identifiable(nxmg, P(Variable('Severe Acute Respiratory Syndrome') @ Variable('angiotensin II')))
     """
     nxmg = bel_to_nxmg(
         graph,

--- a/src/y0_bio/io/bel.py
+++ b/src/y0_bio/io/bel.py
@@ -4,6 +4,7 @@
 
 from typing import Optional
 
+import pybel
 import pybel.constants as pc
 from ananke.graphs import ADMG
 from pybel import BELGraph
@@ -15,6 +16,7 @@ __all__ = [
     'bel_to_nxmg',
     'bel_to_admg',
     'bel_to_causaleffect',
+    'emmaa_to_nxmg',
 ]
 
 CORRELATIVE_RELATIONS = pc.CORRELATIVE_RELATIONS | {pc.CORRELATION}
@@ -23,6 +25,7 @@ VALID = {'di', 'bi', 'skip'}
 
 def bel_to_nxmg(
     bel_graph: BELGraph,
+    *,
     include_associations: bool = False,
     indirect_handler: Optional[str] = None,
 ) -> NxMixedGraph:
@@ -72,6 +75,7 @@ def bel_to_nxmg(
 
 def bel_to_admg(
     graph: BELGraph,
+    *,
     include_associations: bool = False,
     indirect_handler: Optional[str] = None,
 ) -> ADMG:
@@ -94,6 +98,7 @@ def bel_to_admg(
 
 def bel_to_causaleffect(
     graph: BELGraph,
+    *,
     include_associations: bool = False,
     indirect_handler: Optional[str] = None,
 ) -> ADMG:
@@ -112,3 +117,27 @@ def bel_to_causaleffect(
         indirect_handler=indirect_handler,
     )
     return nxmg.to_causaleffect()
+
+
+def emmaa_to_nxmg(model: str, date: Optional[str] = None, **kwargs) -> NxMixedGraph:
+    """Get content from EMMAA and convert to a NXMG.
+
+    :param model: The name of the EMMAA model
+    :param date: The optional date of the EMMAA model. See :func:`pybel.from_emmaa`.
+    :param kwargs: Keyword arguments to pass to :func:`bel_to_nxmg`
+    :return: A y0 networkx mixed graph
+
+    The following example uses the `RAS model <https://www.ndexbio.org/#/network/cc9f904f-4ffd-11e9-9f06-0ac135e8bacf>`_
+    on EMMAA.
+
+    >>> from y0.dsl import P, Variable
+    >>> from y0.identify import is_identifiable
+    >>> from y0_bio.io.bel import emmaa_to_nxmg
+    >>> KRAS = Variable('KRAS')
+    >>> MAPK1 = Variable('MAPK1')
+    >>> ras = emmaa_to_nxmg('rasmodel')
+    >>> is_identifiable(ras, P(MAPK1 @ KRAS))
+    True
+    """
+    bel_graph = pybel.from_emmaa(model, date=date)
+    return bel_to_nxmg(bel_graph, **kwargs)

--- a/src/y0_bio/resources/__init__.py
+++ b/src/y0_bio/resources/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+"""Example data and resources."""
+
+import os
+
+__all__ = [
+    'BEL_EXAMPLE',
+]
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+BEL_EXAMPLE = os.path.join(HERE, 'covid_example.bel.nodelink.json')

--- a/src/y0_bio/resources/covid_example.bel.nodelink.json
+++ b/src/y0_bio/resources/covid_example.bel.nodelink.json
@@ -1,0 +1,490 @@
+{
+  "directed": true,
+  "multigraph": true,
+  "graph": {
+    "pybel_version": "0.14.10-dev",
+    "document_metadata": {
+      "name": "Temporary Network",
+      "version": "_akJ3f4e--_"
+    },
+    "namespace_url": {},
+    "namespace_pattern": {},
+    "annotation_url": {},
+    "annotation_pattern": {},
+    "annotation_list": {},
+    "biodati_network_id": "01E9HFK1WPDF1W198Y3T86EGV8",
+    "annotation_curie": [],
+    "annotation_miriam": []
+  },
+  "nodes": [
+    {
+      "function": "Abundance",
+      "concept": {
+        "namespace": "CHEBI",
+        "name": "angiotensin II"
+      },
+      "id": "17c2386466aa664335d7eeca2063bf1f",
+      "bel": "a(CHEBI:\"angiotensin II\")"
+    },
+    {
+      "function": "Abundance",
+      "concept": {
+        "namespace": "TAX",
+        "name": "Severe acute respiratory syndrome coronavirus 2"
+      },
+      "id": "c41851da59cc36c21b2e8acf24c1f46d",
+      "bel": "a(TAX:\"Severe acute respiratory syndrome coronavirus 2\")"
+    },
+    {
+      "function": "BiologicalProcess",
+      "concept": {
+        "namespace": "GO",
+        "name": "epidermal growth factor receptor signaling pathway"
+      },
+      "id": "bd8c8ef63fe64c16b5c234873e164931",
+      "bel": "bp(GO:\"epidermal growth factor receptor signaling pathway\")"
+    },
+    {
+      "function": "BiologicalProcess",
+      "concept": {
+        "namespace": "GO",
+        "name": "pattern recognition receptor signaling pathway"
+      },
+      "id": "7318f23bd3ef6a3393c5bda5d247821a",
+      "bel": "bp(GO:\"pattern recognition receptor signaling pathway\")"
+    },
+    {
+      "function": "BiologicalProcess",
+      "concept": {
+        "namespace": "GO",
+        "name": "positive regulation of interleukin-6 production"
+      },
+      "id": "42b95ca6d521f67bf2dacfc5aa7da5a9",
+      "bel": "bp(GO:\"positive regulation of interleukin-6 production\")"
+    },
+    {
+      "function": "BiologicalProcess",
+      "concept": {
+        "namespace": "GO",
+        "name": "tumor necrosis factor-mediated signaling pathway"
+      },
+      "id": "a4c18d71b2df953793e49c1a7699c5ac",
+      "bel": "bp(GO:\"tumor necrosis factor-mediated signaling pathway\")"
+    },
+    {
+      "function": "Complex",
+      "concept": {
+        "namespace": "GO",
+        "name": "NF-kappaB complex"
+      },
+      "id": "2b8e47488405cbf906efe3bac140985b",
+      "bel": "complex(GO:\"NF-kappaB complex\")"
+    },
+    {
+      "function": "Complex",
+      "members": [
+        {
+          "function": "Protein",
+          "concept": {
+            "namespace": "HGNC",
+            "name": "IL6"
+          },
+          "id": "8a1d3c4828c5416eba867c395cc65caa",
+          "bel": "p(HGNC:IL6)"
+        },
+        {
+          "function": "Protein",
+          "concept": {
+            "namespace": "HGNC",
+            "name": "STAT3"
+          },
+          "id": "9523cd88bdb7daf4a0aaf38eb43fbe28",
+          "bel": "p(HGNC:STAT3)"
+        }
+      ],
+      "id": "69ed28f0beb7767cf3eff066627216c0",
+      "bel": "complex(p(HGNC:IL6), p(HGNC:STAT3))"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "ACE2"
+      },
+      "id": "bb9a231a2c68ff8f3bad2adad9ed6a94",
+      "bel": "p(HGNC:ACE2)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "ADAM17"
+      },
+      "id": "8351a14adf985bc7b6e72b7fea9a3f1d",
+      "bel": "p(HGNC:ADAM17)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "AGTR1"
+      },
+      "id": "aaf1fa632bd4a29e5095caf17491bb89",
+      "bel": "p(HGNC:AGTR1)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "EGF"
+      },
+      "id": "7c6e2be826c1c81b55f7f6a99b4bab53",
+      "bel": "p(HGNC:EGF)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "IL6"
+      },
+      "id": "8a1d3c4828c5416eba867c395cc65caa",
+      "bel": "p(HGNC:IL6)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "IL6R"
+      },
+      "id": "92536fcad84ecfcda5039c198ce6946d",
+      "bel": "p(HGNC:IL6R)"
+    },
+    {
+      "function": "Protein",
+      "concept": {
+        "namespace": "HGNC",
+        "name": "STAT3"
+      },
+      "id": "9523cd88bdb7daf4a0aaf38eb43fbe28",
+      "bel": "p(HGNC:STAT3)"
+    },
+    {
+      "function": "Pathology",
+      "concept": {
+        "namespace": "MESH",
+        "name": "Severe Acute Respiratory Syndrome"
+      },
+      "id": "ed25a06ed1c83ba5083d0f22650e967f",
+      "bel": "path(MESH:\"Severe Acute Respiratory Syndrome\")"
+    }
+  ],
+  "links": [
+    {
+      "line": 13,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 0,
+      "target": 10,
+      "key": "7673afd97252be43699748ca3feb2e0b"
+    },
+    {
+      "line": 8,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "source": 1,
+      "target": 3,
+      "key": "eebdfacdb7b9086dc79b3976a6de23b5"
+    },
+    {
+      "line": 16,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "object": {
+        "modifier": "Degradation"
+      },
+      "source": 1,
+      "target": 8,
+      "key": "4717cefbdb0e3d3fa012f5318e342a3b"
+    },
+    {
+      "line": 1,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 2,
+      "target": 6,
+      "key": "385c1c99d550166c18667f0057de7dbd"
+    },
+    {
+      "line": 7,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 3,
+      "target": 6,
+      "key": "1b31e5212eaccdd8bf5c6000fa3cf4be"
+    },
+    {
+      "line": 5,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "source": 4,
+      "target": 15,
+      "key": "711479cbf3d6517f91f548db60d58723"
+    },
+    {
+      "line": 0,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 5,
+      "target": 6,
+      "key": "82c40b55fd55e261a77136537c108179"
+    },
+    {
+      "line": 6,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "source": 6,
+      "target": 4,
+      "key": "bcfff1e2a95b32b41a16f12c88f82bb2"
+    },
+    {
+      "line": 9,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "source": 7,
+      "target": 4,
+      "key": "f4ebb243acad5ecbfd996305900a38e9"
+    },
+    {
+      "relation": "partOf",
+      "source": 12,
+      "target": 7,
+      "key": "36e964c22e6aec6068c12001fadfc125"
+    },
+    {
+      "relation": "partOf",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "source": 12,
+      "target": 7,
+      "key": "b3951560316de570fe546784b812311c"
+    },
+    {
+      "relation": "partOf",
+      "source": 14,
+      "target": 7,
+      "key": "7a3a58584f31d46d824c8c420f08b787"
+    },
+    {
+      "relation": "partOf",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "source": 14,
+      "target": 7,
+      "key": "d7ae8b501d6f4b86eb8001ef69c33434"
+    },
+    {
+      "line": 14,
+      "relation": "directlyDecreases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "source": 8,
+      "target": 0,
+      "key": "b61f86c29d0d7205eaf500a988c62807"
+    },
+    {
+      "line": 15,
+      "relation": "directlyDecreases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Degradation"
+      },
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 8,
+      "target": 8,
+      "key": "a0e001167b5cb04b9a00bc96dc941922"
+    },
+    {
+      "line": 3,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "source": 9,
+      "target": 5,
+      "key": "9df81fa73205b855c0e90b0a22ce722f"
+    },
+    {
+      "line": 4,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 9,
+      "target": 11,
+      "key": "3538af0d9d72288bdcbb035def3eba3f"
+    },
+    {
+      "line": 11,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 9,
+      "target": 13,
+      "key": "478fb026f7e31097cac7a410d7318e3a"
+    },
+    {
+      "line": 12,
+      "relation": "directlyIncreases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 10,
+      "target": 9,
+      "key": "69a861c037515dc8c25794ac1c20445a"
+    },
+    {
+      "line": 2,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "source": 11,
+      "target": 2,
+      "key": "9ec9ec11af26f76f817b29cc661b0e38"
+    },
+    {
+      "line": 10,
+      "relation": "increases",
+      "evidence": "SARS-CoV-2 uses angiotensin converting enzyme II (ACE2) and transmembrane serine protease 2 (TMPRSS2) as cell entry receptors, followed by a cytokine-related syndrome, ARDS, which is induced by the hyper-activation of the transcription factor NF-κB, most likely in nonimmune cells including lung epithelial cells. ACE2 molecules on the cell surface are occupied by SARS-CoV-2. Angiotensin 2 (AngII) then increases in the serum due to a reduction of ACE2mediated degradation. SARS-CoV-2 itself activates NF-κB via pattern recognition receptors (PPRs), and the accumulated AngII induces inflammatory cytokines including TNFα and IL-6-soluble (s)IL-6R via disintegrin and metalloprotease 17 (ADAM17), followed by activation of the IL-6  amplifier (IL-6 AMP), which describes enhanced NF -κB activation machinery via the coactivation of NF-κB and transcription factor STAT3. The molecules underlined indicate possible therapeutic targets for COVID-19, which is a cytokine release syndrome (CRS).",
+      "citation": {
+        "namespace": "PubMed",
+        "identifier": "32325025"
+      },
+      "annotations": {},
+      "subject": {
+        "modifier": "Activity"
+      },
+      "object": {
+        "modifier": "Activity"
+      },
+      "source": 13,
+      "target": 7,
+      "key": "b19d5e7471d0dca3ed82e27e0ea0753d"
+    }
+  ]
+}

--- a/tests/io/test_bel.py
+++ b/tests/io/test_bel.py
@@ -4,11 +4,15 @@
 
 import unittest
 
+import pybel
 from pybel import BELGraph
 from pybel.dsl import Protein
 
+from y0.dsl import P, Variable
 from y0.graph import NxMixedGraph
+from y0.identify import is_identifiable
 from y0_bio.io.bel import bel_to_nxmg
+from y0_bio.resources import BEL_EXAMPLE
 
 TEST_CITATION = '1234'
 TEST_EVIDENCE = 'ev'
@@ -58,3 +62,12 @@ class TestBELImport(unittest.TestCase):
             ],
         )
         self.nxmg_equal(expected, bel_to_nxmg(bel_graph, include_associations=True))
+
+    def test_identifiable(self):
+        """Test a BEL example for identifiability."""
+        bel_graph = pybel.load(BEL_EXAMPLE)
+        nxmg = bel_to_nxmg(bel_graph)
+        self.assertTrue(is_identifiable(
+            nxmg,
+            P(Variable('Severe Acute Respiratory Syndrome') @ Variable('angiotensin II')),
+        ))


### PR DESCRIPTION
- [x] Add wrapper around `pybel.from_emmaa` and BEL converter
- ~Handle cyclic graphs~ (next PR)

@djinnome @srtaheri when getting arbitrary graphs from BEL or INDRA, what should we do when they're not acyclic? For example, in this PR, I've added the `y0_bio.io.bel.emmaa_to_nxmg()` function and an example that grabs the relatively small [RAS Model](https://emmaa.indra.bio/dashboard/rasmodel?tab=model) from EMMAA (can be visualized on [NDEx](https://www.ndexbio.org/#/network/cc9f904f-4ffd-11e9-9f06-0ac135e8bacf)).

```python
from y0.dsl import P, Variable
from y0.identify import is_identifiable
from y0_bio.io.bel import emmaa_to_nxmg

KRAS = Variable('KRAS')
MAPK1 = Variable('MAPK1')

ras = emmaa_to_nxmg('rasmodel')
print(is_identifiable(ras, P(MAPK1 @ KRAS)))
```

Gives the following traceback:

```python-traceback
Traceback (most recent call last):
  File "/Users/cthoyt/dev/y0-bio/scratch/use_emmaa.py", line 15, in <module>
    main()
  File "/Users/cthoyt/dev/y0-bio/scratch/use_emmaa.py", line 11, in main
    print(is_identifiable(ras, P(MAPK1 @ KRAS)))
  File "/Users/cthoyt/dev/y0/src/y0/identify.py", line 108, in is_identifiable
    graph = graph.to_admg()
  File "/Users/cthoyt/dev/y0/src/y0/graph.py", line 60, in to_admg
    return ADMG(vertices=vertices, di_edges=di_edges, bi_edges=bi_edges)
  File "/Users/cthoyt/.virtualenvs/bel2scm/lib/python3.9/site-packages/ananke/graphs/admg.py", line 30, in __init__
    super().__init__(vertices=vertices, di_edges=di_edges, bi_edges=bi_edges, **kwargs)
  File "/Users/cthoyt/.virtualenvs/bel2scm/lib/python3.9/site-packages/ananke/graphs/sg.py", line 30, in __init__
    raise TypeError("TypeError: Graph is not acyclic")
TypeError: TypeError: Graph is not acyclic
```